### PR TITLE
Force safer whitenoise versions >= 4.1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
     install_requires=[
-        'whitenoise>=3.1',
+        # 4.1.3 fix avoids exposing server files when whitenoise is misconfigured
+        'whitenoise>=4.1.3',
     ],
     extras_require={
         'pipeline': [


### PR DESCRIPTION
Version 4.1.3 is the first that safely handles
dangerous whitenoise configuration options that
if poorly set can expose arbitrary server files:

    WHITENOISE_AUTOREFRESH=True
    WHITENOISE_USE_FINDERS=True